### PR TITLE
Backport MODULE_IMPORT_NS literal string fix from upstream Linux

### DIFF
--- a/compat/UPSTRM/compat.h
+++ b/compat/UPSTRM/compat.h
@@ -27,6 +27,7 @@
 #define IB_UMEM_HAS_NO_NMAP
 #define IB_CM_LISTEN_WITHOUT_MASK
 #define HAVE_CLASS_MODULE_CLASS_CREATE
+#define MODULE_IMPORT_NS_HAS_STRING
 
 #include "compat_common.h"
 

--- a/drivers/infiniband/ulp/rv/gpu.h
+++ b/drivers/infiniband/ulp/rv/gpu.h
@@ -53,7 +53,11 @@ static inline int num_user_pages_gpu(u64 addr, u64 len)
 #include <linux/dma-resv.h>
 
 #ifdef MODULE_IMPORT_NS_DMA_BUF_FOR_INTEL_GPU_DIRECT
+#ifdef MODULE_IMPORT_NS_HAS_STRING
 MODULE_IMPORT_NS("DMA_BUF");
+#else
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
 #endif
 
 #define INTEL_GPU_PAGE_SHIFT 12


### PR DESCRIPTION
This patch fixes a build failure in the RV kernel module caused by the upstream Linux change in [commit cdd30ebb1b9f36159d66f088b61aee264e649d7a](https://github.com/torvalds/linux/commit/cdd30ebb1b9f36159d66f088b61aee264e649d7a)
.

The MODULE_IMPORT_NS macro now requires a literal string argument. The previous code:

MODULE_IMPORT_NS(DMA_BUF);


has been updated to:

MODULE_IMPORT_NS("DMA_BUF");